### PR TITLE
Eliminate N+1 queries from dashboard

### DIFF
--- a/app/facades/github_facade.rb
+++ b/app/facades/github_facade.rb
@@ -13,17 +13,32 @@ class GithubFacade
 
   def followers
     api_data(:followers).map do |follower|
-      GithubUser.new(follower)
+      local_user = local_users(:followers)
+                   .detect{|u| u.github_id == follower[:id]}
+      GithubUser.new(follower, local_user)
     end
   end
 
   def following
     api_data(:following).map do |user|
-      GithubUser.new(user)
+      local_user = local_users(:following)
+                   .detect{|u| u.github_id == user[:id]}
+      GithubUser.new(user, local_user)
     end
   end
 
   private
+
+  def local_users(endpoint)
+    case endpoint
+    when :followers
+      @_follower_users ||= User.where(github_id: api_data(endpoint)
+                                                 .map{|user| user[:id]})
+    when :following
+      @_following_users ||= User.where(github_id: api_data(endpoint)
+                                                  .map{|user| user[:id]})
+    end
+  end
 
   def api_data(endpoint)
     case endpoint

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -3,15 +3,13 @@
 class GithubUser
   attr_reader :handle,
               :profile_url,
-              :github_id
+              :github_id,
+              :local_user
 
-  def initialize(user_hash)
+  def initialize(user_hash, local_user)
     @handle = user_hash[:login]
     @profile_url = user_hash[:html_url]
     @github_id = user_hash[:id]
-  end
-
-  def local_user
-    @_local_user ||= User.find_by(github_id: @github_id)
+    @local_user = local_user
   end
 end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -7,7 +7,7 @@ describe GithubUser do
           html_url: "https://test_link.com"
           }
 
-    test_user = GithubUser.new(attributes)
+    test_user = GithubUser.new(attributes, nil)
 
     expect(test_user.handle).to eq('Test User')
     expect(test_user.profile_url).to eq('https://test_link.com')


### PR DESCRIPTION
Prior to this, each GithubUser instance did a single query to get its associated User out of our database at the time it was displayed in the view.

Moved this logic into the GithubFacade so it could pull out all associated local Users in a single query.