### PR TITLE
Checkin fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,10 +40,7 @@ class SessionsController < ApplicationController
   end
 
   def handle_oauth
-    current_user.update_attribute(:github_token,
-                                  auth_hash[:credentials][:token])
-    current_user.update_attribute(:github_id,
-                                  auth_hash[:uid])
+    current_user.link_github(auth_hash)
     redirect_to dashboard_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,6 +42,8 @@ class SessionsController < ApplicationController
   def handle_oauth
     current_user.update_attribute(:github_token,
                                   auth_hash[:credentials][:token])
+    current_user.update_attribute(:github_id,
+                                  auth_hash[:uid])
     redirect_to dashboard_path
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,9 @@ class User < ApplicationRecord
           .joins(:tutorial)
           .order(:tutorial_id, :position)
   end
+
+  def link_github(auth_hash)
+    update_attribute(:github_token, auth_hash[:credentials][:token])
+    update_attribute(:github_id, auth_hash[:uid])
+  end
 end


### PR DESCRIPTION
Fixing issues discovered during project check-in. When linking to Github, user's Github ID now saves to the database.